### PR TITLE
scoreboard: consistent date time format

### DIFF
--- a/scoreboard/scripts/mods/scoreboard/scoreboard_history.lua
+++ b/scoreboard/scripts/mods/scoreboard/scoreboard_history.lua
@@ -108,7 +108,7 @@ mod.get_scoreboard_history_entries = function(self, scan_dir)
 			entry.file = file
 			entry.file_path = file_path
 			local date_str = string.sub(file, 1, string.len(file) - 4)
-			entry.date = _os.date("%c", tonumber(date_str))
+			entry.date = _os.date("%Y-%m-%d %H:%M:%S", tonumber(date_str))
 			entries[#entries+1] = entry
 		else
 			missing_file = true


### PR DESCRIPTION
I'm not saying `%c` has problem, but it is inconsistent in different environments. By using `%Y-%m-%d %H:%M:%S` format, we can always get consistent and unambiguous result (e.g. `2023-04-04 12:30:00`), you won't mix up month and day like in the UK/US formats

`%Y-%m-%d %a %H:%M:%S` if you want weekday names