### PR TITLE
Add scoreboard height setting

### DIFF
--- a/scoreboard/scripts/mods/scoreboard/Scoreboard_localization.lua
+++ b/scoreboard/scripts/mods/scoreboard/Scoreboard_localization.lua
@@ -945,4 +945,8 @@ return {
 		ru = "Общий счет",
 		["zh-cn"] = "总分数",
 	},
+	scoreboard_panel_height = {
+		en = "Scoreboard Panel Height",
+		["zh-cn"] = "记分板面板大小",
+	},
 }

--- a/scoreboard/scripts/mods/scoreboard/scoreboard/scoreboard_view_settings.lua
+++ b/scoreboard/scripts/mods/scoreboard/scoreboard/scoreboard_view_settings.lua
@@ -1,6 +1,8 @@
+local mod = get_mod("scoreboard")
+
 local scoreboard_view_settings = {
     shading_environment = "content/shading_environments/ui/system_menu",
-    scoreboard_size = {1000, 580},
+    scoreboard_size = {1000, mod:get("scoreboard_panel_height")},
     scoreboard_row_height = 20,
     scoreboard_row_header_height = 30,
     scoreboard_row_big_height = 36,

--- a/scoreboard/scripts/mods/scoreboard/scoreboard_data.lua
+++ b/scoreboard/scripts/mods/scoreboard/scoreboard_data.lua
@@ -6,6 +6,11 @@ return {
 	allow_rehooking = true,
 	options = {
 		widgets = {
+			{["setting_id"] = "scoreboard_panel_height",
+				["type"] = "numeric",
+				["default_value"] = 580,
+				["range"] = {300, 1000},
+			},
 			{["setting_id"] = "open_scoreboard_history",
 				["type"] = "keybind",
 				["default_value"] = {"f5"},


### PR DESCRIPTION
This PR adds a new setting for users to adjust the scoreboard panel height as they want.
The default value remains 580, and the range is from 300 to 1000.