### PR TITLE
Fix for Hotfix #73 (1.8.5)

### DIFF
--- a/weapon_customization/scripts/mods/weapon_customization/patches/inventory_weapon_cosmetics_view.lua
+++ b/weapon_customization/scripts/mods/weapon_customization/patches/inventory_weapon_cosmetics_view.lua
@@ -2653,6 +2653,27 @@ mod:hook_require("scripts/ui/views/inventory_weapon_cosmetics_view/inventory_wea
 				filter_on_weapon_template = true,
 				apply_on_preview = function(real_item, presentation_item)
 					self:_preview_item(presentation_item)
+				end,
+				-- Copied from scripts/ui/views/inventory_weapon_cosmetics_view/inventory_weapon_cosmetics_view.lua
+				-- 		taken from the one where `content[idk]["slot_name"] = "slot_weapon_skin",`
+				-- 		there's another one from `content[idk]["slot_name"] = "slot_trinket_1",`
+				generate_visual_item_function = function (real_item, selected_item)
+					local visual_item
+	
+					if real_item.gear then
+						visual_item = MasterItems.create_preview_item_instance(selected_item)
+					else
+						visual_item = table.clone_instance(selected_item)
+					end
+	
+					visual_item.gear_id = real_item.gear_id
+					visual_item.slot_weapon_skin = real_item
+	
+					if visual_item.gear.masterDataInstance.overrides then
+						visual_item.gear.masterDataInstance.overrides.slot_weapon_skin = real_item
+					end
+	
+					return visual_item
 				end
 			}
 		end

--- a/weapon_customization/scripts/mods/weapon_customization/patches/inventory_weapon_cosmetics_view.lua
+++ b/weapon_customization/scripts/mods/weapon_customization/patches/inventory_weapon_cosmetics_view.lua
@@ -2647,7 +2647,7 @@ mod:hook_require("scripts/ui/views/inventory_weapon_cosmetics_view/inventory_wea
 			-- Add tab
 			content[3] = {
 				display_name = "loc_weapon_cosmetics_customization",
-				slot_name = "slot_weapon_skin",
+				slot_name = "slot_weapon_skin_ewc",
 				item_type = "WEAPON_SKIN",
 				icon = "content/ui/materials/icons/system/settings/category_gameplay",
 				filter_on_weapon_template = true,

--- a/weapon_customization/scripts/mods/weapon_customization/patches/inventory_weapon_cosmetics_view.lua
+++ b/weapon_customization/scripts/mods/weapon_customization/patches/inventory_weapon_cosmetics_view.lua
@@ -2653,27 +2653,6 @@ mod:hook_require("scripts/ui/views/inventory_weapon_cosmetics_view/inventory_wea
 				filter_on_weapon_template = true,
 				apply_on_preview = function(real_item, presentation_item)
 					self:_preview_item(presentation_item)
-				end,
-				-- Copied from scripts/ui/views/inventory_weapon_cosmetics_view/inventory_weapon_cosmetics_view.lua
-				-- 		taken from the one where `content[idk]["slot_name"] = "slot_weapon_skin",`
-				-- 		there's another one from `content[idk]["slot_name"] = "slot_trinket_1",` but that doesn't work
-				generate_visual_item_function = function (real_item, selected_item)
-					local visual_item
-	
-					if real_item.gear then
-						visual_item = MasterItems.create_preview_item_instance(selected_item)
-					else
-						visual_item = table.clone_instance(selected_item)
-					end
-	
-					visual_item.gear_id = real_item.gear_id
-					visual_item.slot_weapon_skin = real_item
-	
-					if visual_item.gear.masterDataInstance.overrides then
-						visual_item.gear.masterDataInstance.overrides.slot_weapon_skin = real_item
-					end
-	
-					return visual_item
 				end
 			}
 		end

--- a/weapon_customization/scripts/mods/weapon_customization/patches/inventory_weapon_cosmetics_view.lua
+++ b/weapon_customization/scripts/mods/weapon_customization/patches/inventory_weapon_cosmetics_view.lua
@@ -2656,7 +2656,7 @@ mod:hook_require("scripts/ui/views/inventory_weapon_cosmetics_view/inventory_wea
 				end,
 				-- Copied from scripts/ui/views/inventory_weapon_cosmetics_view/inventory_weapon_cosmetics_view.lua
 				-- 		taken from the one where `content[idk]["slot_name"] = "slot_weapon_skin",`
-				-- 		there's another one from `content[idk]["slot_name"] = "slot_trinket_1",`
+				-- 		there's another one from `content[idk]["slot_name"] = "slot_trinket_1",` but that doesn't work
 				generate_visual_item_function = function (real_item, selected_item)
 					local visual_item
 	


### PR DESCRIPTION
`[Script Error]: ...eapon_cosmetics_view/inventory_weapon_cosmetics_view.lua:942: attempt to call local 'generate_visual_item_function' (a nil value)`

Basically, I just changed the slot name of the tab to avoid the game calling a function that doesn't exist.

---

In `scripts/ui/views/inventory_weapon_cosmetics_view/inventory_weapon_cosmetics_view.lua` there is now additional code in the function `InventoryWeaponCosmeticsView.cb_switch_tab`.  It creates a table `layouts` (which I think is for each preview box per weapon skin/trinket). 

To fill this out, the function checks `if self._items_by_slot[slot_name] then` to execute the code that calls `generate_visual_item_function(item, self._selected_item)`.

The lack of this function in this tab (`content[3]`) is what's causing the crash, though if you make it return something that doesn't match the visual_item format (idk the specifics), it'll also crash.  Copying over `generate_visual_item_function()` from the tab named "slot_weapon_skin" avoids the crash, but leaves skin previews on top of the customization menu every time.

![skin previews on top of customization menu](https://i.imgur.com/JeOqpcb.png)

When changing the slot_name, there isn't an entry for the custom slot in the `_items_by_slot` table, so `layout` is never filled out, and nothing gets drawn on top of the current customization menu.


When changing the slot name, it seems to work fine as if the hotfix never happened.
