### PR TITLE
Some initial offsets for human weapons

### DIFF
--- a/visible_equipment/scripts/mods/visible_equipment/weapons/autogun_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/autogun_p1_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/autopistol_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/autopistol_p1_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/bolter_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/bolter_p1_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/boltpistol_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/boltpistol_p1_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/chainaxe_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/chainaxe_p1_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/chainaxe_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/chainaxe_p1_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, 90, 80),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/chainsword_2h_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/chainsword_2h_p1_m1.lua
@@ -23,10 +23,53 @@ return {
 			},
 			right = {
 				node = "j_spine2",
-				position = vector3_box(.5, .2, .15),
+				position = vector3_box(.4, .11, .12),
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(0, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.15, -0.1, 0.16),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.13, 0.15, 0.16),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, 0.11, 0.2),
+                rotation = vector3_box(-40, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .11, 0.2),
+                rotation = vector3_box(-40, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/chainsword_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/chainsword_p1_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/chainsword_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/chainsword_p1_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p1_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p1_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, 90, 80),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p2_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p2_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, 90, 80),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p3_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p3_m1.lua
@@ -35,6 +35,27 @@ return {
                 rotation = vector3_box(0, -120, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p3_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p3_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p3_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p3_m1.lua
@@ -30,8 +30,9 @@ return {
         hip_back = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.05, -.2, 0),
-                rotation = vector3_box(0, 0, 90),
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p3_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p3_m1.lua
@@ -23,7 +23,7 @@ return {
 			},
 			right = {
 				node = "j_spine2",
-				position = vector3_box(.3, .2, .15),
+				position = vector3_box(0.3, 0.13, 0.12),
 				rotation = vector3_box(10, -90, -90),
 			},
 		},

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p3_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combataxe_p3_m1.lua
@@ -27,6 +27,20 @@ return {
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 100),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combatknife_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combatknife_p1_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combatknife_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combatknife_p1_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p1_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p1_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p2_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p2_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p3_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p3_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p3_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/combatsword_p3_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/flamer_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/flamer_p1_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/forcestaff_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/forcestaff_p1_m1.lua
@@ -16,10 +16,52 @@ local mod = get_mod("weapon_customization")
 return {
     offsets = {
         default = {
+        	right = {
+				node = "j_spine2",
+				position = vector3_box(.3, .175, -.15),
+				rotation = vector3_box(10, 90, -90),
+			},
+		},
+        leg_left = {
             right = {
-                node = "j_spine2",
-                position = vector3_box(.3, .175, -.15),
-                rotation = vector3_box(10, 90, -90),
+                node = "j_leftupleg",
+                position = vector3_box(0, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(0, -.125, 0),
+                rotation = vector3_box(10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.15, -0.1, 0.16),
+                rotation = vector3_box(0, 60, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.13, 0.15, 0.12),
+                rotation = vector3_box(180, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, 0.11, 0.2),
+                rotation = vector3_box(140, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .11, 0.2),
+                rotation = vector3_box(140, 180, 30),
             },
         },
         backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/forcesword_2h_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/forcesword_2h_p1_m1.lua
@@ -23,10 +23,53 @@ return {
 			},
 			right = {
 				node = "j_spine2",
-				position = vector3_box(.4, .2, .15),
-				rotation = vector3_box(10, -90, -90),
+				position = vector3_box(.4, .13, .12),
+				rotation = vector3_box(20, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(0, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.15, -0.1, 0.16),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.13, 0.15, 0.16),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, 0.11, 0.15),
+                rotation = vector3_box(-40, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .11, 0.15),
+                rotation = vector3_box(-40, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/forcesword_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/forcesword_p1_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/lasgun_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/lasgun_p1_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/lasgun_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/lasgun_p2_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/lasgun_p3_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/lasgun_p3_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/laspistol_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/laspistol_p1_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/plasmagun_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/plasmagun_p1_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_2h_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_2h_p1_m1.lua
@@ -23,8 +23,8 @@ return {
 			},
 			right = {
 				node = "j_spine2",
-				position = vector3_box(.4, .11, .12),
-				rotation = vector3_box(10, -90, -90),
+				position = vector3_box(.4, .12, .12),
+				rotation = vector3_box(30, -90, -90),
 			},
 		},
         leg_left = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_2h_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_2h_p1_m1.lua
@@ -23,10 +23,53 @@ return {
 			},
 			right = {
 				node = "j_spine2",
-				position = vector3_box(.5, .2, .15),
+				position = vector3_box(.4, .11, .12),
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(0, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.15, -0.1, 0.16),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.13, 0.15, 0.16),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, 0.11, 0.2),
+                rotation = vector3_box(-40, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .11, 0.2),
+                rotation = vector3_box(-40, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p1_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p1_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p2_m1.lua
@@ -60,14 +60,14 @@ return {
             right = {
                 node = "j_hips",
                 position = vector3_box(-.2, .125, 0.1),
-                rotation = vector3_box(-40, 180, 0),
+                rotation = vector3_box(-40, 180, 180),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
                 position = vector3_box(.2, .125, 0.1),
-                rotation = vector3_box(-40, 180, 30),
+                rotation = vector3_box(-40, 180, 180),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p2_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p2_m1.lua
@@ -31,14 +31,14 @@ return {
             right = {
                 node = "j_leftupleg",
                 position = vector3_box(0.1, 0.11, -0.06),
-                rotation = vector3_box(-10, 75, 280),
+                rotation = vector3_box(-10, 75, -280),
             },
         },
         leg_right = {
             right = {
                 node = "j_rightupleg",
                 position = vector3_box(-.1, -.125, 0),
-                rotation = vector3_box(-10, 250, -90),
+                rotation = vector3_box(-10, 250, 90),
             },
         },
         hip_back = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p2_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_p2_m1.lua
@@ -46,14 +46,14 @@ return {
                 node = "j_hips",
                 -- x, -0.15, x is better for overcoats
                 position = vector3_box(0.075, -0.1, 0.15),
-                rotation = vector3_box(0, -120, 90),
+                rotation = vector3_box(0, -120, 270),
             },
         },
         hip_front = {
             right = {
                 node = "j_hips",
                 position = vector3_box(0.075, 0.15, 0.15),
-                rotation = vector3_box(0, -110, 90),
+                rotation = vector3_box(0, -110, 270),
             },
         },
         hip_left = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_shield_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_shield_p1_m1.lua
@@ -84,7 +84,7 @@ return {
             right = {
                 node = "j_hips",
                 position = vector3_box(-.2, .125, 0.1),
-                rotation = vector3_box(-40, 180, 0),
+                rotation = vector3_box(-40, 180, 180),
             },
         },
         hip_right = {
@@ -96,7 +96,7 @@ return {
             right = {
                 node = "j_hips",
                 position = vector3_box(.2, .125, 0.1),
-                rotation = vector3_box(-40, 180, 30),
+                rotation = vector3_box(-40, 180, 180),
             },
         },
         backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_shield_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_shield_p1_m1.lua
@@ -60,7 +60,7 @@ return {
             right = {
                 node = "j_hips",
                 position = vector3_box(0.075, -0.1, 0.15),
-                rotation = vector3_box(0, -120, 90),
+                rotation = vector3_box(0, -120, 270),
             },
         },
         hip_front = {
@@ -72,7 +72,7 @@ return {
             right = {
                 node = "j_hips",
                 position = vector3_box(0.075, 0.15, 0.15),
-                rotation = vector3_box(0, -110, 90),
+                rotation = vector3_box(0, -110, 270),
             },
         },
         hip_left = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_shield_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_shield_p1_m1.lua
@@ -36,7 +36,7 @@ return {
             right = {
                 node = "j_leftupleg",
                 position = vector3_box(0.1, 0.11, -0.06),
-                rotation = vector3_box(-10, 75, 280),
+                rotation = vector3_box(-10, 75, -280),
             },
         },
         leg_right = {
@@ -48,7 +48,7 @@ return {
             right = {
                 node = "j_rightupleg",
                 position = vector3_box(-.1, -.125, 0),
-                rotation = vector3_box(-10, 250, -90),
+                rotation = vector3_box(-10, 250, 90),
             },
         },
         hip_back = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_shield_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powermaul_shield_p1_m1.lua
@@ -27,6 +27,78 @@ return {
                 rotation = vector3_box(10, -90, -90),
             },
         },
+        leg_left = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .175, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .175, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .175, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .175, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .175, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
+            },
+        },
+        hip_right = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .175, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
+            },
+        },
         backpack = {
             left = {
                 node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powersword_2h_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powersword_2h_p1_m1.lua
@@ -23,10 +23,53 @@ return {
 			},
 			right = {
 				node = "j_spine2",
-				position = vector3_box(.4, .2, .15),
-				rotation = vector3_box(10, -90, -90),
+				position = vector3_box(.4, .11, .12),
+				rotation = vector3_box(20, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(0, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.15, -0.1, 0.16),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.13, 0.15, 0.16),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, 0.11, 0.15),
+                rotation = vector3_box(-40, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .11, 0.15),
+                rotation = vector3_box(-40, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powersword_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powersword_p1_m1.lua
@@ -23,7 +23,7 @@ return {
 			},
 			right = {
 				node = "j_spine2",
-				position = vector3_box(.3, .2, .15),
+				position = vector3_box(.3, .15, .2),
 				rotation = vector3_box(10, -90, -90),
 			},
 		},

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powersword_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powersword_p1_m1.lua
@@ -59,15 +59,15 @@ return {
         hip_left = {
             right = {
                 node = "j_hips",
-                position = vector3_box(-.2, .125, 0),
-                rotation = vector3_box(-60, 180, 0),
+                position = vector3_box(-.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 0),
             },
         },
         hip_right = {
             right = {
                 node = "j_hips",
-                position = vector3_box(.2, .125, 0),
-                rotation = vector3_box(-60, 180, 30),
+                position = vector3_box(.2, .125, 0.1),
+                rotation = vector3_box(-40, 180, 30),
             },
         },
 		backpack = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/powersword_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/powersword_p1_m1.lua
@@ -27,6 +27,49 @@ return {
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0.1, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.075, -0.1, 0.15),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.075, 0.15, 0.15),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(-60, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(-60, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/shotgun_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/shotgun_p1_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/shotgun_p2_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/shotgun_p2_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/shotgun_p4_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/shotgun_p4_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/shotpistol_shield_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/shotpistol_shield_p1_m1.lua
@@ -27,6 +27,78 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .225, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
+        hip_back = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .225, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, -.2, 0),
+                rotation = vector3_box(0, 0, 90),
+            },
+        },
+        leg_left = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .225, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(.1, .125, -.15),
+                rotation = vector3_box(290, 220, 100),
+            },
+        },
+        leg_right = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .225, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(-.1, -.125, 0),
+                rotation = vector3_box(290, 220 + 180, 280 + 180),
+            },
+        },
+        hip_left = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .225, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, .125, 0),
+                rotation = vector3_box(180+45, 180, 0),
+            },
+        },
+        hip_right = {
+            left = {
+                node = "j_spine2",
+                position = vector3_box(.2, .225, -.125),
+                rotation = vector3_box(0, 90, 90),
+            },
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .125, 0),
+                rotation = vector3_box(180+45, 180, 30),
+            },
+        },
         backpack = {
             left = {
                 node = "j_spine2",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/stubrevolver_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/stubrevolver_p1_m1.lua
@@ -22,6 +22,13 @@ return {
                 rotation = vector3_box(-10, 0, 90),
             },
         },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.05, .2, 0.1),
+                rotation = vector3_box(0, -20, 90),
+            },
+        },
         hip_back = {
             right = {
                 node = "j_hips",

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/thunderhammer_2h_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/thunderhammer_2h_p1_m1.lua
@@ -23,8 +23,8 @@ return {
 			},
 			right = {
 				node = "j_spine2",
-				position = vector3_box(.4, .11, .12),
-				rotation = vector3_box(10, -90, -90),
+				position = vector3_box(.4, .12, .12),
+				rotation = vector3_box(30, -90, -90),
 			},
 		},
         leg_left = {

--- a/visible_equipment/scripts/mods/visible_equipment/weapons/thunderhammer_2h_p1_m1.lua
+++ b/visible_equipment/scripts/mods/visible_equipment/weapons/thunderhammer_2h_p1_m1.lua
@@ -23,10 +23,53 @@ return {
 			},
 			right = {
 				node = "j_spine2",
-				position = vector3_box(.5, .2, .15),
+				position = vector3_box(.4, .11, .12),
 				rotation = vector3_box(10, -90, -90),
 			},
 		},
+        leg_left = {
+            right = {
+                node = "j_leftupleg",
+                position = vector3_box(0, 0.11, -0.06),
+                rotation = vector3_box(-10, 75, 280),
+            },
+        },
+        leg_right = {
+            right = {
+                node = "j_rightupleg",
+                position = vector3_box(0, -.125, 0),
+                rotation = vector3_box(-10, 250, -90),
+            },
+        },
+        hip_back = {
+            right = {
+                node = "j_hips",
+                -- x, -0.15, x is better for overcoats
+                position = vector3_box(0.15, -0.1, 0.16),
+                rotation = vector3_box(0, -120, 90),
+            },
+        },
+        hip_front = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(0.13, 0.15, 0.16),
+                rotation = vector3_box(0, -110, 90),
+            },
+        },
+        hip_left = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(-.2, 0.11, 0.2),
+                rotation = vector3_box(-40, 180, 0),
+            },
+        },
+        hip_right = {
+            right = {
+                node = "j_hips",
+                position = vector3_box(.2, .11, 0.2),
+                rotation = vector3_box(-40, 180, 30),
+            },
+        },
 		backpack = {
 			left = {
 				node = "j_spine2",


### PR DESCRIPTION
- Added hip_front to human ranged weapons
- Added all offset slots to Force Staves, with custom offsets
- Weapons with Arbites Shield always have the shield on the back (position copied from default for now)
- Added all offset slots to human melee weapons,, with two general groups
    - Long weapons: Force Greatsword, Relic Blade, Thunder Hammer, Crusher
     - Short weapons: the rest
- Arbites mauls (and the one with the shield) are rotated a bit differently to fit the grip position

I didn't do anything related to center mass offset