### PR TITLE
Bound by Duty quick fixes

### DIFF
--- a/weapon_customization/scripts/mods/weapon_customization/patches/inventory_background_view.lua
+++ b/weapon_customization/scripts/mods/weapon_customization/patches/inventory_background_view.lua
@@ -196,7 +196,7 @@ mod:hook_require("scripts/ui/views/inventory_background_view/inventory_backgroun
 		end
 		if self.inventory_view then
 			local wbn = self.inventory_view._widgets_by_name
-				if wbn then wbn.name_text.content.text = self._item_name or "n/a" end
+				if wbn and wbn.name_text and wbn.name_text.content then wbn.name_text.content.text = self._item_name or "n/a" end
 		end
 	end
 

--- a/weapon_customization/scripts/mods/weapon_customization/patches/misc.lua
+++ b/weapon_customization/scripts/mods/weapon_customization/patches/misc.lua
@@ -98,24 +98,24 @@ mod:hook(CLASS.MissionIntroView, "init", function(func, self, settings, context,
 	func(self, settings, context, ...)
 end)
 
-mod:hook(CLASS.OutOfBoundsManager, "pre_update", function(func, self, shared_state, ...)
-	local hard_cap_out_of_bounds_units = shared_state.hard_cap_out_of_bounds_units
-	local soft_cap_out_of_bounds_units = shared_state.soft_cap_out_of_bounds_units
-	local world = shared_state.world
-
-	table.clear(soft_cap_out_of_bounds_units)
-	table.clear(hard_cap_out_of_bounds_units)
-
-	-- local num_hard_cap_units, _ = 
-	world_update_out_of_bounds_checker(world, hard_cap_out_of_bounds_units, soft_cap_out_of_bounds_units)
-	for _, unit in pairs(hard_cap_out_of_bounds_units) do
-		local u = tostring(unit)
-		if u == "#ID[e90c4e5ba603c2af]" or u == "#ID[465f4895f3dc98d1]" then
-			unit_set_local_position(unit, 1, vector3_zero())
-		end
-	end
-	-- local local_hard_cap_out_of_bounds_units = self._local_hard_cap_out_of_bounds_units
-end)
+--mod:hook(CLASS.OutOfBoundsManager, "pre_update", function(func, self, shared_state, ...)
+--	local hard_cap_out_of_bounds_units = shared_state.hard_cap_out_of_bounds_units
+--	local soft_cap_out_of_bounds_units = shared_state.soft_cap_out_of_bounds_units
+--	local world = shared_state.world
+--
+--	table.clear(soft_cap_out_of_bounds_units)
+--	table.clear(hard_cap_out_of_bounds_units)
+--
+--	-- local num_hard_cap_units, _ = 
+--	world_update_out_of_bounds_checker(world, hard_cap_out_of_bounds_units, soft_cap_out_of_bounds_units)
+--	for _, unit in pairs(hard_cap_out_of_bounds_units) do
+--		local u = tostring(unit)
+--		if u == "#ID[e90c4e5ba603c2af]" or u == "#ID[465f4895f3dc98d1]" then
+--			unit_set_local_position(unit, 1, vector3_zero())
+--		end
+--	end
+--	-- local local_hard_cap_out_of_bounds_units = self._local_hard_cap_out_of_bounds_units
+--end)
 
 -- ##### ┌─┐┬─┐┌─┐┌─┐┬ ┬  ┌─┐┬─┐ ┬ ####################################################################################
 -- ##### │  ├┬┘├─┤└─┐├─┤  ├┤ │┌┴┬┘ ####################################################################################


### PR DESCRIPTION
[mediafire mirror of this in case anyone wants to download it easily](https://www.mediafire.com/file/j97jz05ao9jdifr/weapon_customization_Bound_by_Duty_bandaid.zip/file)
# Crash on opening the inventory
Added a check to see if name_text exists in `inventory_background_view.lua`

```
<<Script Error>>[string "./../mods/weapon_customization/scripts/mods/w..."]:199: attempt to index field 'name_text' (a nil value)<</Script Error>>
<<Lua Stack>>  [1] ./../mods/weapon_customization/scripts/mods/weapon_customization/patches/inventory_background_view.lua:199: in function add_unit_manipulation
```

# Hooking nonexistent function
Looks like this function got moved/renamed so the hook fails and sends a message on startup. I just commented out the whole hook in `misc.lua` since it seems to work fine without.

In the [new code](https://github.com/Aussiemon/Darktide-Source-Code/blob/master/scripts/managers/out_of_bounds/out_of_bounds_manager.lua), it looks like it got replaced by `post_update`.

```
[MOD][weapon_customization][ERROR] (hook): trying to hook function or method that doesn't exist: [OutOfBoundsManager.pre_update]
 ```