### PR TITLE
Scoreboard saved difficulty values

### DIFF
--- a/scoreboard/scripts/mods/scoreboard/history/scoreboard_history_view.lua
+++ b/scoreboard/scripts/mods/scoreboard/history/scoreboard_history_view.lua
@@ -195,13 +195,13 @@ ScoreboardHistoryView._setup_category_config = function(self, scan_dir)
             if category_config.timer ~= "" then
                 mission_subname = "\n"..category_config.timer
             end
-            if category_config.mission_challenge ~= "" then
-                local mission_challenge = Danger[tonumber(category_config.mission_challenge)]
-                if mission_challenge then
+            if category_config.mission_resistance ~= "" then
+                local mission_resistance = Danger[tonumber(category_config.mission_resistance)]
+                if mission_resistance then
                     if mission_subname == "" then
-                        mission_subname = "\n"..Localize(mission_challenge.display_name)
+                        mission_subname = "\n"..Localize(mission_resistance.display_name)
                     else
-                        mission_subname = mission_subname.." | "..Localize(mission_challenge.display_name)
+                        mission_subname = mission_subname.." | "..Localize(mission_resistance.display_name)
                     end
                 end
             end

--- a/scoreboard/scripts/mods/scoreboard/scoreboard.lua
+++ b/scoreboard/scripts/mods/scoreboard/scoreboard.lua
@@ -177,6 +177,9 @@ end
 mod.set_mission_challenge = function(self, mission_challenge)
 	self.mission_challenge = mission_challenge
 end
+mod.set_mission_resistance = function(self, mission_resistance)
+	self.mission_resistance = mission_resistance
+end
 mod.set_victory_defeat = function(self, victory_defeat)
 	self.victory_defeat = victory_defeat
 end
@@ -350,6 +353,7 @@ mod:hook(CLASS.StateGameplay, "on_enter", function(func, self, parent, params, c
 	mod:set_mission_name(params.mission_name)
 	mod:set_mission_circumstance(params.mechanism_data.circumstance_name)
 	mod:set_mission_challenge(params.mechanism_data.challenge)
+	mod:set_mission_resistance(params.mechanism_data.resistance)
 	mod:initialize_timer()
 end)
 

--- a/scoreboard/scripts/mods/scoreboard/scoreboard_history.lua
+++ b/scoreboard/scripts/mods/scoreboard/scoreboard_history.lua
@@ -220,7 +220,7 @@ mod.save_scoreboard_history_entry = function(self, sorted_rows)
 
 	-- Mission
 	local timer = (_os.time() or 0) - (self.timer or 0)
-	file:write("#mission;"..tostring(self.mission_name)..";"..tostring(self.mission_challenge)..";"..tostring(self.mission_circumstance)..";"..tostring(self.victory_defeat)..";"..tostring(timer).."\n")
+	file:write("#mission;"..tostring(self.mission_name)..";"..tostring(self.mission_resistance)..";"..tostring(self.mission_circumstance)..";"..tostring(self.victory_defeat)..";"..tostring(timer).."\n")
 
 	-- Players
 	local count = 0
@@ -363,11 +363,11 @@ mod.load_scoreboard_history_entry = function(self, path, date, only_head)
 			-- Read mission info
 			local name = info[2]
 			entry.mission_name = name
-			entry.mission_challenge = ""
+			entry.mission_resistance = ""
 			entry.mission_circumstance = ""
 			entry.victory_defeat = ""
 			entry.timer = ""
-			if info[3] ~= nil then entry.mission_challenge = info[3] end
+			if info[3] ~= nil then entry.mission_resistance = info[3] end
 			if info[4] ~= nil then entry.mission_circumstance = info[4] end
 			if info[5] ~= nil then entry.victory_defeat = info[5] end
 			if ( info[6] ~= nil and tonumber(info[6]) ~= nil ) then


### PR DESCRIPTION
When Auric got made into its own difficulty and Sedition was removed, the difficulties on the scoreboard history were one off unless it was Auric.

tldr there's a new value to check for accurate difficulty indexing

---

In `scripts/settings/difficulty/danger_settings` 

Before it was
- Danger[1] = Sedition, challenge = 1
- Danger[2] = Uprising, challenge = 2
- Danger[3] = Malice, challenge = 3
...

And now it's
- Danger[1] = Uprising, challenge = 2
- Danger[2] = Malice, challenge = 3
- Danger[3] = Heresy, challenge = 3
- Danger[4] = Damnation, challenge = 5
- Danger[5] = Auric, challenge = 5

so the challenge value no longer matched the index, then using the challenge as the index gave the wrong value (except for Auric where it was 5 for both). Now there's also `resistance`, which does line up with the indices, so using that works for the old method